### PR TITLE
Handle null/false/undefined children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import { Children, cloneElement } from 'react';
 
+const hasChildren = child => child && child.props && child.props.children;
+const hasComplexChildren = child => hasChildren(child) && typeof child.props.children === 'object';
+
 export default {
 
   ...Children,
@@ -26,8 +29,7 @@ export default {
       .toArray(children)
       .filter(deepFilterFn)
       .map((child) => {
-        if (child.props && child.props.children
-          && typeof child.props.children === 'object') {
+        if (hasComplexChildren(child)) {
           // Clone the child that has children and filter them too
           return cloneElement(child, {
             ...child.props,
@@ -70,8 +72,7 @@ export default {
   deepMap(children, deepMapFn) {
     return Children
       .map(children, (child) => {
-        if (child.props && child.props.children
-          && typeof child.props.children === 'object') {
+        if (hasComplexChildren(child)) {
           // Clone the child that has children and map them too
           return deepMapFn(cloneElement(child, {
             ...child.props,
@@ -90,8 +91,7 @@ export default {
   deepForEach(children, deepForEachFn) {
     Children
       .forEach(children, (child) => {
-        if (child.props && child.props.children
-          && typeof child.props.children === 'object') {
+        if (hasComplexChildren(child)) {
           // Each inside the child that has children
           this.deepForEach(child.props.children, deepForEachFn);
         }
@@ -109,8 +109,7 @@ export default {
     return Children
       .toArray(children)
       .find((child) => {
-        if (child.props && child.props.children
-          && typeof child.props.children === 'object') {
+        if (hasComplexChildren(child)) {
           // Find inside the child that has children
           return this.deepFind(child.props.children, deepFindFn);
         }
@@ -128,7 +127,7 @@ export default {
       .toArray(children)
       .reduce((flattened, child) => [
         ...flattened,
-        child.props && child.props.children ? this.onlyText(child.props.children) : child,
+        hasChildren(child) ? this.onlyText(child.props.children) : child,
       ], [])
       .join('');
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,7 +59,7 @@ describe('Children', () => {
     const DeepMapped = props => (
       <div>
         { Children.deepMap(props.children,
-          child => (
+          child => child && (
             child.type === 'b'
               ? cloneElement(child, { ...child.props, className: 'mapped' })
               : child
@@ -69,7 +69,21 @@ describe('Children', () => {
     );
     DeepMapped.propTypes = { children: PropTypes.node.isRequired };
     const wrapper = shallow(
-      <DeepMapped><b>1</b><b>2</b><span><b>3</b></span><div><div><b>4</b></div></div></DeepMapped>,
+      <DeepMapped>
+        <b>1</b>
+        <b>2</b>
+        <span>
+          <b>3</b>
+        </span>
+        <div>
+          <div>
+            <b>4</b>
+          </div>
+        </div>
+        {null && <div>will not show up</div>}
+        {false && <div>will not show up</div>}
+        {undefined && <div>will not show up</div>}
+      </DeepMapped>,
     );
     expect(wrapper.find('.mapped')).toBePresent();
     expect(wrapper.find('.mapped')).toHaveLength(4);
@@ -80,7 +94,7 @@ describe('Children', () => {
     const DeepForEached = props => (
       <div>
         { Children.deepForEach(props.children, (child) => {
-          if (child.type === 'b') {
+          if (child && child.type === 'b') {
             texts.push(child.props.children);
           }
         }) }
@@ -89,7 +103,19 @@ describe('Children', () => {
     DeepForEached.propTypes = { children: PropTypes.node.isRequired };
     shallow(
       <DeepForEached>
-        <b>1</b><b>2</b><span><b>3</b></span><div><div><b>4</b></div></div>
+        <b>1</b>
+        <b>2</b>
+        <span>
+          <b>3</b>
+        </span>
+        <div>
+          <div>
+            <b>4</b>
+          </div>
+        </div>
+        {null && <div>will not show up</div>}
+        {false && <div>will not show up</div>}
+        {undefined && <div>will not show up</div>}
       </DeepForEached>,
     );
     expect(texts).toEqual(['1', '2', '3', '4']);
@@ -98,7 +124,19 @@ describe('Children', () => {
   it('deep find', () => {
     const DeepFound = props => (<div>{ Children.deepFind(props.children, child => child.type === 'i') }</div>);
     DeepFound.propTypes = { children: PropTypes.node.isRequired };
-    const wrapper = shallow(<DeepFound><b>1</b><b>2</b><span><i>3</i></span><i>4</i></DeepFound>);
+    const wrapper = shallow(
+      <DeepFound>
+        <b>1</b>
+        <b>2</b>
+        <span>
+          <i>3</i>
+        </span>
+        <i>4</i>
+        {null && <div>will not show up</div>}
+        {false && <div>will not show up</div>}
+        {undefined && <div>will not show up</div>}
+      </DeepFound>,
+    );
     expect(wrapper.find('i')).toBePresent();
     expect(wrapper.find('i')).toHaveLength(1);
     expect(wrapper).toHaveText('3');


### PR DESCRIPTION
At the moment `deepFilter`, `deepMap`, `deepForEach` and `deepFind` fail if traversing an element which has null or undefined children. The kind you get when you have `{someCondition && <div>something</div>}` in JSX. This fixes the issue by ignoring those elements when recursively traversing them.