### PR TITLE
Added .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,5 @@ coverage
 
 # build and temp folders
 !dist
+
+.babelrc


### PR DESCRIPTION
Added .babelrc to .npmignore because react-native failed to bundle this module with error:
`error: bundling failed: Error: Couldn't find preset "env" relative to directory`