### PR TITLE
Introduce named exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     }
   }],
   "rules": {
+    "arrow-body-style": "off",
     "function-paren-newline": "off",
     "react/jsx-filename-extension": "off",
     "jsx-a11y/href-no-hash": "off",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "bundlesize": [
     {
       "path": "dist/index.js",
-      "maxSize": "1.2 kB"
+      "maxSize": "1.25 kB"
     }
   ],
   "resolutions": {

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -2,13 +2,15 @@ import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Children from '..';
+import {
+  deepFilter, deepFind, deepForEach, deepMap, filter, groupByType, onlyText,
+} from '..';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Children', () => {
   test('filter', () => {
-    const Filtered = ({ children }) => <div>{ Children.filter(children, item => item.type === 'span') }</div>;
+    const Filtered = ({ children }) => <div>{ filter(children, item => item.type === 'span') }</div>;
     Filtered.propTypes = { children: PropTypes.node.isRequired };
     const wrapper = shallow(
       <Filtered>
@@ -23,7 +25,7 @@ describe('Children', () => {
   });
 
   test('deep filter', () => {
-    const DeepFiltered = ({ children }) => <div>{ Children.deepFilter(children, item => item.type === 'span') }</div>;
+    const DeepFiltered = ({ children }) => <div>{ deepFilter(children, item => item.type === 'span') }</div>;
     DeepFiltered.propTypes = { children: PropTypes.node.isRequired };
     const wrapper = shallow(
       <DeepFiltered>
@@ -46,9 +48,9 @@ describe('Children', () => {
   test('group by type', () => {
     const Grouped = ({ children }) => (
       <div>
-        <div className="spans">{ Children.groupByType(children, ['span', 'i'], 'rest').span }</div>
-        <div className="rest">{ Children.groupByType(children, ['span', 'i'], 'rest').rest }</div>
-        <div className="empty">{ Children.groupByType(children, ['span', 'i'], 'rest').i }</div>
+        <div className="spans">{ groupByType(children, ['span', 'i'], 'rest').span }</div>
+        <div className="rest">{ groupByType(children, ['span', 'i'], 'rest').rest }</div>
+        <div className="empty">{ groupByType(children, ['span', 'i'], 'rest').i }</div>
       </div>
     );
     Grouped.propTypes = { children: PropTypes.node.isRequired };
@@ -71,7 +73,7 @@ describe('Children', () => {
   test('deep map', () => {
     const DeepMapped = ({ children }) => (
       <div>
-        { Children.deepMap(children,
+        { deepMap(children,
           child => child && (
             child.type === 'b'
               ? cloneElement(child, { ...child.props, className: 'mapped' })
@@ -106,7 +108,7 @@ describe('Children', () => {
     const texts = [];
     const DeepForEached = ({ children }) => (
       <div>
-        { Children.deepForEach(children, (child) => {
+        { deepForEach(children, (child) => {
           if (child && child.type === 'b') {
             texts.push(child.props.children);
           }
@@ -135,7 +137,7 @@ describe('Children', () => {
   });
 
   test('deep find', () => {
-    const DeepFound = ({ children }) => (<div>{ Children.deepFind(children, child => child.type === 'i') }</div>);
+    const DeepFound = ({ children }) => (<div>{ deepFind(children, child => child.type === 'i') }</div>);
     DeepFound.propTypes = { children: PropTypes.node.isRequired };
     const wrapper = shallow(
       <DeepFound>
@@ -156,7 +158,7 @@ describe('Children', () => {
   });
 
   test('only text', () => {
-    const OnlyText = ({ children }) => (<div>{ Children.onlyText(children) }</div>);
+    const OnlyText = ({ children }) => (<div>{ onlyText(children) }</div>);
     OnlyText.propTypes = { children: PropTypes.node.isRequired };
     const wrapper = shallow(
       <OnlyText>

--- a/src/index.js
+++ b/src/index.js
@@ -9,133 +9,139 @@ const hasChildren = (child: Element<any>): boolean => Boolean(
 const hasComplexChildren = (child: Element<any>): boolean => hasChildren(child)
   && typeof child.props.children === 'object';
 
+/**
+ * Filter children
+ * @param   {object} children - React component children
+ * @param {function} filterFn - Array filter callback
+ * @returns  {array}          - Filtered children
+ */
+export const filter = (children: number, filterFn: (child: Node) => boolean): Node => {
+  return Children
+    .toArray(children)
+    .filter(filterFn);
+};
+
+/**
+ * Filter children and its children
+ * @param   {object} children     - React component children
+ * @param {function} deepFilterFn - Deep Filter callback
+ * @returns  {array}              - Deep Filtered children
+ */
+export const deepFilter = (children: Node, deepFilterFn: (child: Node) => boolean): Node => {
+  return Children
+    .toArray(children)
+    .filter(deepFilterFn)
+    .map((child) => {
+      if (hasComplexChildren(child)) {
+        // Clone the child that has children and filter them too
+        return cloneElement(child, {
+          ...child.props,
+          children: deepFilter(child.props.children, deepFilterFn),
+        });
+      }
+      return child;
+    });
+};
+
+/**
+ * Group children by type and puts in a rest key
+ * the types not indicated
+ * @param   {object} children - React component children
+ * @param {string[]} types    - Array of child types
+ * @param   {string} rest     - Object key name where non types will be saved
+ * @returns {object}          - Map of the types and rest
+ */
+export const groupByType = (children: Node, types: Array<string>, rest: string): Object => {
+  return Children
+    .toArray(children)
+    .reduce((group, child) => {
+      const isGrouped = types.includes(child.type);
+      const addChild = isGrouped ? child.props.children : child;
+      const key = isGrouped ? child.type : rest;
+
+      return {
+        ...group,
+        [key]: [...(group[key] || []), addChild],
+      };
+    }, {});
+};
+
+/**
+ * Map children and its children
+ * @param   {object} children  - React component children
+ * @param {function} deepMapFn - Deep Map callback
+ * @returns  {array}           - Deep Mapped children
+ */
+export const deepMap = (children: Node, deepMapFn: (child: Node) => Node): Node => {
+  return Children
+    .map(children, (child) => {
+      if (hasComplexChildren(child)) {
+        // Clone the child that has children and map them too
+        return deepMapFn(cloneElement(child, {
+          ...child.props,
+          children: deepMap(child.props.children, deepMapFn),
+        }));
+      }
+      return deepMapFn(child);
+    });
+};
+
+/**
+ * ForEach children and its children
+ * @param   {object} children      - React component children
+ * @param {function} deepForEachFn - Deep Map callback
+ */
+export const deepForEach = (children: Node, deepForEachFn: (child: Node) => void): void => {
+  Children
+    .forEach(children, (child) => {
+      if (hasComplexChildren(child)) {
+        // Each inside the child that has children
+        deepForEach(child.props.children, deepForEachFn);
+      }
+      deepForEachFn(child);
+    });
+};
+
+/**
+ * Find in children and its children
+ * @param   {object} children   - React component children
+ * @param {function} deepFindFn - Deep Map callback
+ * @returns  {array}            - Children found
+ */
+export const deepFind = (children: Node, deepFindFn: (child: Node) => boolean): Node | void => {
+  return Children
+    .toArray(children)
+    .find((child) => {
+      if (hasComplexChildren(child)) {
+        // Find inside the child that has children
+        return deepFind(child.props.children, deepFindFn);
+      }
+      return deepFindFn(child);
+    });
+};
+
+/**
+ * Get only the text in children and its children
+ * @param   {object} children - React component children
+ * @returns  {string}         - Text of all children
+ */
+export const onlyText = (children: Node): string => {
+  return Children
+    .toArray(children)
+    .reduce((flattened, child) => [
+      ...flattened,
+      hasChildren(child) ? onlyText(child.props.children) : child,
+    ], [])
+    .join('');
+};
+
 export default {
-
   ...Children,
-
-  /**
-   * Filter children
-   * @param   {object} children - React component children
-   * @param {function} filterFn - Array filter callback
-   * @returns  {array}          - Filtered children
-   */
-  filter(children: number, filterFn: (child: Node) => boolean): Node {
-    return Children
-      .toArray(children)
-      .filter(filterFn);
-  },
-
-  /**
-   * Filter children and its children
-   * @param   {object} children     - React component children
-   * @param {function} deepFilterFn - Deep Filter callback
-   * @returns  {array}              - Deep Filtered children
-   */
-  deepFilter(children: Node, deepFilterFn: (child: Node) => boolean): Node {
-    return Children
-      .toArray(children)
-      .filter(deepFilterFn)
-      .map((child) => {
-        if (hasComplexChildren(child)) {
-          // Clone the child that has children and filter them too
-          return cloneElement(child, {
-            ...child.props,
-            children: this.deepFilter(child.props.children, deepFilterFn),
-          });
-        }
-        return child;
-      });
-  },
-
-  /**
-   * Group children by type and puts in a rest key
-   * the types not indicated
-   * @param   {object} children - React component children
-   * @param {string[]} types    - Array of child types
-   * @param   {string} rest     - Object key name where non types will be saved
-   * @returns {object}          - Map of the types and rest
-   */
-  groupByType(children: Node, types: Array<string>, rest: string): Object {
-    return Children
-      .toArray(children)
-      .reduce((group, child) => {
-        const isGrouped = types.includes(child.type);
-        const addChild = isGrouped ? child.props.children : child;
-        const key = isGrouped ? child.type : rest;
-
-        return {
-          ...group,
-          [key]: [...(group[key] || []), addChild],
-        };
-      }, {});
-  },
-
-  /**
-   * Map children and its children
-   * @param   {object} children  - React component children
-   * @param {function} deepMapFn - Deep Map callback
-   * @returns  {array}           - Deep Mapped children
-   */
-  deepMap(children: Node, deepMapFn: (child: Node) => Node): Node {
-    return Children
-      .map(children, (child) => {
-        if (hasComplexChildren(child)) {
-          // Clone the child that has children and map them too
-          return deepMapFn(cloneElement(child, {
-            ...child.props,
-            children: this.deepMap(child.props.children, deepMapFn),
-          }));
-        }
-        return deepMapFn(child);
-      });
-  },
-
-  /**
-   * ForEach children and its children
-   * @param   {object} children      - React component children
-   * @param {function} deepForEachFn - Deep Map callback
-   */
-  deepForEach(children: Node, deepForEachFn: (child: Node) => void): void {
-    Children
-      .forEach(children, (child) => {
-        if (hasComplexChildren(child)) {
-          // Each inside the child that has children
-          this.deepForEach(child.props.children, deepForEachFn);
-        }
-        deepForEachFn(child);
-      });
-  },
-
-  /**
-   * Find in children and its children
-   * @param   {object} children   - React component children
-   * @param {function} deepFindFn - Deep Map callback
-   * @returns  {array}            - Children found
-   */
-  deepFind(children: Node, deepFindFn: (child: Node) => boolean): Node | void {
-    return Children
-      .toArray(children)
-      .find((child) => {
-        if (hasComplexChildren(child)) {
-          // Find inside the child that has children
-          return this.deepFind(child.props.children, deepFindFn);
-        }
-        return deepFindFn(child);
-      });
-  },
-
-  /**
-   * Get only the text in children and its children
-   * @param   {object} children - React component children
-   * @returns  {string}         - Text of all children
-   */
-  onlyText(children: Node): string {
-    return Children
-      .toArray(children)
-      .reduce((flattened, child) => [
-        ...flattened,
-        hasChildren(child) ? this.onlyText(child.props.children) : child,
-      ], [])
-      .join('');
-  },
+  filter,
+  deepFilter,
+  groupByType,
+  deepMap,
+  deepForEach,
+  deepFind,
+  onlyText,
 };


### PR DESCRIPTION
Currently you have to import this way:

```js
import Children from 'react-children-utilities'
```

It would be great if we could import named exports like:

```js
import { onlyText } from 'react-children-utilities'
```

Closes #8.
