### PR TITLE
fix: deepFind to return the element found instead of its root

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "bundlesize": [
     {
       "path": "dist/index.js",
-      "maxSize": "1.4 kB"
+      "maxSize": "1.5 kB"
     }
   ],
   "resolutions": {

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -162,6 +162,7 @@ describe('Children', () => {
     );
     expect(wrapper.find('i')).toExist();
     expect(wrapper.find('i')).toHaveLength(1);
+    expect(wrapper.find('span')).not.toExist();
     expect(wrapper).toHaveText('3');
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,13 +63,20 @@ export const deepForEach = (children, deepForEachFn) => {
 };
 
 export const deepFind = (children, deepFindFn) => {
-  return Children.toArray(children).find((child) => {
+  let found;
+  Children.toArray(children).find((child) => {
     if (hasComplexChildren(child)) {
       // Find inside the child that has children
-      return deepFind(child.props.children, deepFindFn);
+      found = deepFind(child.props.children, deepFindFn);
+      return typeof (found) !== 'undefined';
     }
-    return deepFindFn(child);
+    if (deepFindFn(child)) {
+      found = child;
+      return true;
+    }
+    return false;
   });
+  return found;
 };
 
 export const onlyText = (children) => {


### PR DESCRIPTION
**Description**
This changes behaviour of `deepFind` to return the element found by the test function, instead of its root element.

**Closing issues**
Closes #12 
