### PR TITLE
fix: pass index & children to deepMap, deepForeach & deepFind

### DIFF
--- a/src/lib/deepFind.ts
+++ b/src/lib/deepFind.ts
@@ -1,25 +1,31 @@
 import { Children, isValidElement, ReactNode } from 'react';
 import hasComplexChildren from './hasComplexChildren';
 
-export type FindFunction = (child: ReactNode, index?: number, children?: ReactNode[]) => boolean;
+export type FindFunction = (
+  child: ReactNode,
+  index?: number,
+  children?: readonly ReactNode[],
+) => boolean;
 
 const deepFind = (children: ReactNode, deepFindFn: FindFunction): ReactNode | undefined => {
   let found;
 
-  Children.toArray(children).find((child: ReactNode) => {
-    if (deepFindFn(child)) {
-      found = child;
-      return true;
-    }
+  Children.toArray(children).find(
+    (child: ReactNode, index: number, findChildren: readonly ReactNode[]) => {
+      if (deepFindFn(child, index, findChildren)) {
+        found = child;
+        return true;
+      }
 
-    if (isValidElement(child) && hasComplexChildren(child)) {
-      // Find inside the child that has children
-      found = deepFind(child.props.children, deepFindFn);
-      return typeof found !== 'undefined';
-    }
+      if (isValidElement(child) && hasComplexChildren(child)) {
+        // Find inside the child that has children
+        found = deepFind(child.props.children, deepFindFn);
+        return typeof found !== 'undefined';
+      }
 
-    return false;
-  });
+      return false;
+    },
+  );
 
   return found;
 };

--- a/src/lib/deepForEach.ts
+++ b/src/lib/deepForEach.ts
@@ -1,15 +1,15 @@
 import { Children, isValidElement, ReactNode } from 'react';
 import hasComplexChildren from './hasComplexChildren';
 
-export type ForEachFunction = (child: ReactNode, index?: number, children?: ReactNode[]) => void;
+export type ForEachFunction = (child: ReactNode, index?: number) => void;
 
 const deepForEach = (children: ReactNode, deepForEachFn: ForEachFunction): void => {
-  Children.forEach(children, (child: ReactNode) => {
+  Children.forEach(children, (child: ReactNode, index: number) => {
     if (isValidElement(child) && hasComplexChildren(child)) {
       // Each inside the child that has children
       deepForEach(child.props.children, deepForEachFn);
     }
-    deepForEachFn(child);
+    deepForEachFn(child, index);
   });
 };
 

--- a/src/lib/deepMap.ts
+++ b/src/lib/deepMap.ts
@@ -1,21 +1,27 @@
 import { Children, cloneElement, isValidElement, ReactNode } from 'react';
 import hasComplexChildren from './hasComplexChildren';
 
-export type MapFunction = (child: ReactNode, index?: number, children?: ReactNode[]) => ReactNode;
+export type MapFunction = (
+  child: ReactNode,
+  index?: number,
+  children?: readonly ReactNode[],
+) => ReactNode;
 
 const deepMap = (children: ReactNode, deepMapFn: MapFunction): ReactNode[] => {
-  return Children.toArray(children).map((child: ReactNode) => {
-    if (isValidElement(child) && hasComplexChildren(child)) {
-      // Clone the child that has children and map them too
-      return deepMapFn(
-        cloneElement(child, {
-          ...child.props,
-          children: deepMap(child.props.children, deepMapFn),
-        }),
-      );
-    }
-    return deepMapFn(child);
-  });
+  return Children.toArray(children).map(
+    (child: ReactNode, index: number, mapChildren: readonly ReactNode[]) => {
+      if (isValidElement(child) && hasComplexChildren(child)) {
+        // Clone the child that has children and map them too
+        return deepMapFn(
+          cloneElement(child, {
+            ...child.props,
+            children: deepMap(child.props.children, deepMapFn),
+          }),
+        );
+      }
+      return deepMapFn(child, index, mapChildren);
+    },
+  );
 };
 
 export default deepMap;


### PR DESCRIPTION
Suggested implementation of #16

