### PR TITLE
fix: add test and fix for empty child for onlyText

### DIFF
--- a/src/lib/__tests__/onlyText.spec.tsx
+++ b/src/lib/__tests__/onlyText.spec.tsx
@@ -42,6 +42,16 @@ describe('onlyText', () => {
     expect(wrapper).toHaveText('');
   });
 
+  it('on empty child', () => {
+    const wrapper = shallow(
+      <OnlyText>
+        <span />
+      </OnlyText>,
+    );
+
+    expect(wrapper).toHaveText('');
+  });
+
   it('on text', () => {
     const wrapper = shallow(<OnlyText>test 1 test 2</OnlyText>);
 

--- a/src/lib/onlyText.ts
+++ b/src/lib/onlyText.ts
@@ -23,6 +23,8 @@ const onlyText = (children: ReactNode): string => {
 
     if (isValidElement(child) && hasChildren(child)) {
       newText = onlyText(child.props.children);
+    } else if (isValidElement(child) && !hasChildren(child)) {
+      newText = '';
     } else {
       newText = childToString(child);
     }


### PR DESCRIPTION
<!--
**IMPORTANT**: Please do not create a Pull Request **without creating an issue first** so it can be discussed.
-->

<!-- Indicate which issue is being closed with this pull request. -->

Closes #18.

## Description

<!--
Explain the changes proposed in the pull request as well as
the problem that these changes solve

Please add any information relevant on context that could help the review.
-->

[Codesandbox example of the issue](https://codesandbox.io/s/festive-shtern-mmuhz?file=/src/App.js)

Self-closing components caused this error
```
Converting circular structure to JSON
    --> starting at object with constructor 'FiberRootNode'
    |     property 'current' -> object with constructor 'FiberNode'
    --- property 'stateNode' closes the circle
```

I added a test that tests the method when the child is self-closing.
The fix I add is in the area that checks for nested children. I added a check that it is an element but does not have children. At that point, I decided to return an empty string.

I feel this may be a bandaid because self-closing components often take props to make additional children and return a much larger nested structure. I am not sure we have access to this info in the child at this point.

<!-- It is **required** that **all github checks pass** for the review. -->
